### PR TITLE
LRAC-11274 Avoid validating attributes because the documentDownloaded event may have a null version

### DIFF
--- a/modules/apps/analytics/analytics-client-js/src/utils/constants.js
+++ b/modules/apps/analytics/analytics-client-js/src/utils/constants.js
@@ -14,7 +14,7 @@
 
 // AC Version
 
-export const ANALYTICS_CLIENT_VERSION = '1.0.5';
+export const ANALYTICS_CLIENT_VERSION = '1.0.6';
 
 // Default Config
 

--- a/modules/apps/analytics/analytics-client-js/src/utils/validators.js
+++ b/modules/apps/analytics/analytics-client-js/src/utils/validators.js
@@ -31,7 +31,10 @@ const isValidEvent = ({eventId, eventProps}) => {
 	]);
 	const validationsValue = _validate([
 		validateMaxLength(VALIDATION_PROPERTY_VALUE_MAXIMUM_LENGTH),
-		validateAttributeType,
+
+		// LRAC-11274 Avoid make validation to prevent bugs for now
+		// validateAttributeType
+
 	]);
 	let errors = [];
 

--- a/modules/apps/analytics/analytics-client-js/test/analytics.js
+++ b/modules/apps/analytics/analytics-client-js/test/analytics.js
@@ -318,7 +318,9 @@ describe('Analytics', () => {
 			expect(console.error).toHaveBeenCalledTimes(1);
 		});
 
-		it('returns a type error if the attribute type is not valid', () => {
+		// LRAC-11274 Skip this test for now
+
+		xit('returns a type error if the attribute type is not valid', () => {
 			Analytics = AnalyticsClient.create(INITIAL_CONFIG);
 
 			console.error = jest.fn((val) => val);


### PR DESCRIPTION
- LRAC-11274 Avoid validating attributes because the documentDownloaded event may have a null version
- LRAC-11274 Update analytics client version
