### PR TITLE
cookies

### DIFF
--- a/modules/apps/analytics/analytics-client-js/src/analytics.js
+++ b/modules/apps/analytics/analytics-client-js/src/analytics.js
@@ -409,7 +409,10 @@ class Analytics {
 	}
 
 	_isTrackingDisabled() {
+		const isLiferayCookieEnabled = Liferay?.Util?.Cookie && Liferay?.Util?.Cookie?.get(Liferay?.Util?.Cookie?.TYPES.PERFORMANCE) === 'true'
+		
 		return (
+			!isLiferayCookieEnabled ||
 			ENV.ac_client_disable_tracking ||
 			navigator.doNotTrack === '1' ||
 			navigator.doNotTrack === 'yes'
@@ -472,7 +475,7 @@ class Analytics {
 			Liferay.Util.Cookie.set(
 				key,
 				data,
-				Liferay.Util.Cookie.TYPES.PERSONALIZATION,
+				Liferay.Util.Cookie.TYPES.PERFORMANCE,
 				{
 					expires,
 					secure: true,

--- a/modules/apps/analytics/analytics-client-js/src/utils/storage.js
+++ b/modules/apps/analytics/analytics-client-js/src/utils/storage.js
@@ -12,10 +12,10 @@ const getItem = (key) => {
 	try {
 		let item;
 
-		if (Liferay && Liferay.Util && Liferay.Util.LocalStorage) {
+		if (Liferay?.Util?.LocalStorage) {
 			item = Liferay.Util.LocalStorage.getItem(
 				key,
-				Liferay.Util.LocalStorage.TYPES.PERSONALIZATION
+				Liferay.Util.LocalStorage.TYPES.PERFORMANCE
 			);
 		}
 		else {
@@ -35,11 +35,11 @@ const setItem = (key, value) => {
 	const Liferay = window.Liferay;
 
 	try {
-		if (Liferay && Liferay.Util && Liferay.Util.LocalStorage) {
+		if (Liferay?.Util?.LocalStorage) {
 			Liferay.Util.LocalStorage.setItem(
 				key,
 				JSON.stringify(value),
-				Liferay.Util.LocalStorage.TYPES.PERSONALIZATION
+				Liferay.Util.LocalStorage.TYPES.PERFORMANCE
 			);
 		}
 		else {
@@ -55,10 +55,10 @@ const removeItem = (key) => {
 	const Liferay = window.Liferay;
 
 	try {
-		if (Liferay && Liferay.Util && Liferay.Util.LocalStorage) {
+		if (Liferay?.Util?.LocalStorage) {
 			Liferay.Util.LocalStorage.removeItem(
 				key,
-				Liferay.Util.LocalStorage.TYPES.PERSONALIZATION
+				Liferay.Util.LocalStorage.TYPES.PERFORMANCE
 			);
 		}
 		else {

--- a/modules/apps/analytics/analytics-web/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
+++ b/modules/apps/analytics/analytics-web/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
@@ -10,7 +10,7 @@
 <meta content="<%= (String)request.getAttribute(AnalyticsWebKeys.ANALYTICS_CLIENT_READABLE_CONTENT) %>" name="data-analytics-readable-content" />
 
 <aui:script senna="temporary" type="text/javascript">
-	var runMiddlewares = function () {
+	var runMiddlewares = () => {
 		<liferay-util:dynamic-include key="/dynamic_include/top_head.jsp#analytics" />
 	};
 
@@ -40,42 +40,68 @@
 			return request;
 		};
 
-		Analytics.create(config, [dxpMiddleware]);
-
-		if (themeDisplay.isSignedIn()) {
-			Analytics.setIdentity({
-				email: themeDisplay.getUserEmailAddress(),
-				name: themeDisplay.getUserName(),
-			});
+		function <portlet:namespace />startTracking() {
+			Analytics.create(config, [dxpMiddleware]);
+	
+			if (themeDisplay.isSignedIn()) {
+				Analytics.setIdentity({
+					email: themeDisplay.getUserEmailAddress(),
+					name: themeDisplay.getUserName(),
+				});
+			}
+		
+			runMiddlewares();
+		
+			Analytics.send('pageViewed', 'Page');
 		}
+		
+		Liferay.on('acceptCookies', () => {
+			<portlet:namespace />startTracking();
+		})
 
-		runMiddlewares();
-
-		Analytics.send('pageViewed', 'Page');
-
+		Liferay.on('declineCookies', () => {
+			if (window.Analytics) {
+				Analytics.dispose();
+			}
+		})
+		
+		<portlet:namespace />startTracking();
+	
 		<c:if test="<%= GetterUtil.getBoolean(PropsUtil.get(PropsKeys.JAVASCRIPT_SINGLE_PAGE_APPLICATION_ENABLED)) %>">
 			Liferay.on('endNavigate', (event) => {
-				Analytics.dispose();
+				function <portlet:namespace />startTrackingSPA() {
+					Analytics.dispose();
 
-				var groupId = themeDisplay.getScopeGroupIdOrLiveGroupId();
-
-				if (
-					!themeDisplay.isControlPanel() &&
-					analyticsClientGroupIds.indexOf(groupId) >= 0
-				) {
-					Analytics.create(config, [dxpMiddleware]);
-
-					if (themeDisplay.isSignedIn()) {
-						Analytics.setIdentity({
-							email: themeDisplay.getUserEmailAddress(),
-							name: themeDisplay.getUserName(),
-						});
+					const groupId = themeDisplay.getScopeGroupIdOrLiveGroupId();
+		
+					if (
+						!themeDisplay.isControlPanel() &&
+						analyticsClientGroupIds.indexOf(groupId) >= 0
+					) {
+						Analytics.create(config, [dxpMiddleware]);
+		
+						if (themeDisplay.isSignedIn()) {
+							Analytics.setIdentity({
+								email: themeDisplay.getUserEmailAddress(),
+								name: themeDisplay.getUserName(),
+							});
+						}
+		
+						runMiddlewares();
+		
+						Analytics.send('pageViewed', 'Page', {page: event.path});
 					}
-
-					runMiddlewares();
-
-					Analytics.send('pageViewed', 'Page', {page: event.path});
 				}
+
+				Liferay.on('acceptCookies', () => {
+					<portlet:namespace />startTrackingSPA();
+				})
+
+				Liferay.on('declineCookies', () => {
+					Analytics.dispose();
+				})
+
+				<portlet:namespace />startTrackingSPA();
 			});
 		</c:if>
 	});

--- a/modules/apps/analytics/analytics-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/analytics/analytics-web/src/main/resources/META-INF/resources/init.jsp
@@ -7,6 +7,8 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner/js/CookiesBanner.js
+++ b/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner/js/CookiesBanner.js
@@ -66,6 +66,8 @@ export default function ({
 			);
 
 			setUserConfigCookie();
+
+			Liferay.fire('acceptCookies');
 		});
 
 		openCookieConsentModal = ({
@@ -110,6 +112,8 @@ export default function ({
 							setBannerVisibility(cookieBanner);
 
 							getOpener().Liferay.fire('closeModal');
+							
+							Liferay.fire('acceptCookies');
 						},
 					},
 					{
@@ -126,6 +130,8 @@ export default function ({
 							setBannerVisibility(cookieBanner);
 
 							getOpener().Liferay.fire('closeModal');
+							
+							Liferay.fire('acceptCookies');
 						},
 					},
 					{
@@ -143,6 +149,8 @@ export default function ({
 							setBannerVisibility(cookieBanner);
 
 							getOpener().Liferay.fire('closeModal');
+							
+							Liferay.fire('declineCookies');
 						},
 					},
 				],
@@ -169,6 +177,8 @@ export default function ({
 			);
 
 			setUserConfigCookie();
+
+			Liferay.fire('declineCookies')
 		});
 	}
 }


### PR DESCRIPTION
- LPS-205071 title_i18n field is now being saved through headless-admin-address API calls
- LPS-205480 Remove scr pojo service wiring design in DDMFormInstanceRecordBatchReindexer
- LPS-205479 Inline TemplateNodeTransformerRegistry
- LPS-205478 Remove useless JournalCreationStrategy
- LPS-205477 Remove scr pojo service wiring design in BookmarksFolderBatchReindexer
- LRCI-3939 Add test-portal-evaluate-pullrequest to the Liferay database
- LRCI-3939 Add test-portal-evaluate-pullrequest to the job entity & definition
- LRCI-3939 Add logic to handle ci:reevaluate github comments
- LRCI-3939 Sort
- LPS-203653 Move classes to content transformer module
- LPS-203653 Module no longer necessary
- LPS-203653 Always invoke HTML content transformer
- LPS-203653 Deprecate method and add simpler version with no type
- LPS-203653 Handle exn as with the aggregate case
- LPS-203653 Type no longer necessary
- LPS-203653 Deprecate content transformer type
- LPS-203653 SF
- LPS-203653 Fix tests
- LPS-203653 No longer needed
- LPS-203653 Update modules.properties
- LPS-203653 There's no easy way to avoid major change; remove deprecated methods
- LPS-203653 Baseline
- LPS-203653 Remove generic type from SF rules
- LPS-203653 ran 'gw formatJavadoc'
- LPS-205097 Make sure the guest users are generated before generating UserPersonalSiteGroupModel as the it has a dependeny on the Gues userId in java code
- LPS-205097 Remove left over guest_user.ftl as we just need to generate guest users for the default company
- LPS-204925 Update debounce typing
- LPS-204475 - Remove feature flag
- LPS-205216 Missing argument for formatting expression
- LRCI-3954 Add method to update build description using the build url
- LRCI-3954 Add methods to get find files, merge commits, & modified files in GWD
- LRCI-3954 Add method to push a set of subrepository commits into portal
- LRCI-3954 Wordsmith
- LRCI-3954 prep next
- Revert "LPS-204273 LPS-204274 LPS-204276 Remove unused references from DLApp wrappers"
- LPS-204716 Create constants for notification freemarker template
- LPS-204716 Split into methods
- LPS-204716 Include portalURL in the general variables
- LPS-204716 Replace portalURL variable by the current value of portalURL when building the notification
- LPS-204716 baseline
- LPS-204716 Rename to _freeMarkerTermValues
- LPS-204716 Cover portalURL FTL variable
- LPS-204716 Isolate this case in another test because it was affected by https://github.com/liferay-echo/liferay-portal/pull/14829/commits/df6b8866344e716d6fc7f3074839b96e1f47540f
- LPS-204716 It is only used in one place
- LPS-204716 Delete notificationQueueEntry after test run and simplify recipient
- LPS-204716 Not needed
- LPS-204716 SF
- LPS-205263 Change url separator to avoid conflicts
- LPS-205263 Semver
- LPS-199506 Property to specify a "blocked" folder
- LPS-199506 Let each operation provide its own URL
- LPS-199506 Consolidate all folder selection urls in one util class
- LPS-199506 Copy and move criteria should be the same
- LPS-199506 SF - rename methods
- LPS-199506 Provide selection URL to frontend side
- LPS-199506 When moving/copying a folder, mark it as blocked
- LPS-199506 Make class attribute final
- LPS-199506 Start in the parent folder, and prevent navigation to selected folder
- LPS-199506 baseline
- LPS-199506 autoSF
- LPS-199506 as the _blockedFolderId default value is (DLFolderConstants.DEFAULT_PARENT_FOLDER_ID ignore if it is it
- LPS-199506 now info panel needs a itemSelector on request to avoid NPE
- LPS-199506 Initialize item selector in portlet class
- LPS-199506 SF
- LPS-77699 Update Translations
- LPS-205373 - Add missing dependency, aui-component.
- LPS-204716 my bad
- LPS-205367 Change label
- LPS-204464 Remove FF for CSPs nonces
- LPS-205096 - Update a11y-sample-web to ESM
- LPS-205096 - Update a11y-web to ESM
- LPS-205096 - Update alert-support-web to ESM
- LPS-205096 - Update clay-sample-web to ESM
- LPS-205096 - Update collapse-support-web to ESM
- LPS-205096 - Update walkthrough-web to ESM
- LPS-205096 - Update components-sample-web to ESM
- LPS-205096 - Update dropdown-support-web to ESM
- LPS-205096 - Update spa-web to ESM
- LPS-205096 - Update tabs-support-web to ESM
- LPS-205096 - Update tooltip-support-web to ESM
- LPS-205096 - Update walkthrough-sample-web to ESM
- LPS-205096 - Remove this file since it isn't even used
- LPS-205096 - SF
- LPS-205096 - Update node-shims to ESM
- LPS-204967 fix logic, only allow skipping certain directories
- LPS-204967 SF
- LPS-204967 Rename
- LPS-204967 fix properties
- ISSD-2291 Add missing variables
- ISSD-2291 Apply front-end client extentions via site initializer.
- ISSD-2291 Auto SF
- ISSD-2291 Edit css from public site navigation template
- LPS-205476 gradle-plugins-workspace: manually adjust up-to-date status when assemble source changes
- LPS-205476 prep next
- LPS-205476 prep next
- LPS-205476 prep next
- LPS-205476 regen
- LPS-204746 Move logic to the API to be reused
- LPS-204746 Add DDMFormFields to DDMFormInstanceRecordWriterRequest
- LPS-204746 baseline
- LPS-204746 Improve data format for numeric and date fields when exporting form entries
- LPS-204746 Fix tests
- LPS-205557 Modify case to adapt new behavior
- LPS-205403 Do not show lock icon when it is a private layout
- LPS-205116 Adjust sidebar sizing
- LPS-205363 After LPS-202082 portal indexes are tried to update when executing IndexUpdaterUtil#updateAllIndexes if they were not previously updated. Since the test forces the failure it will try to get updated twice.
- LRAC-15330 update validation to make only authorized members to download all requests from the request log
- LRAC-15330 update addParam func to check if there is a defined value
- LRAC-15330 update unit test
- LRAC-15173 add to baseProductEntryIds
- ISSD-2015 Create support ticket escalation structure
- LPS-202928 Update the field names
- LPS-202928 Rebuild the structure of locales and rename the method
- LPS-202929 Add data-language-id and data-field-name to the hidden inputs to have better access to the languageid
- LPS-202928 Update translation manager with TranslationAdminSelector component
- LPS-202929 Update the translation when the event from localized input is listened
- LPS-202928 Add translationProgress prop to show how many translated fields there are at the moment
- LPS-205319 Uses an existing portlet path
- LPS-200303 Don't apply the workflow permissions for the VIEW's action on published layouts as the actually workflowed layout is the draft one so in this case the published layout VIEW model permission should be applied
- LPS-200303 Adds integration tests to assert that the Guest user is allowed to view a published content page or not depending on the layout VIEW permissions for the Guest users
- LPS-200303 Adds integration tests to assert that the Guest user is allowed to view the published content page or not depending on the layout VIEW permissions for the Guest users when there is a new page version at pending status
- LPS-200303 Adds integration tests to assert that the Guest user is NOT allowed to view a never published content page when is in pending status even if the Guest user has VIEW permissions over the layout
- LPS-197643 Increase Handle Size and Create a Connection Area Around the Node
- ISSD-2220 Adjust Commerce capability's localizable description according to spreadsheet
- ISSD-2246 Update style books on Learn Project
- ISSD-2246 Rename CSS Variables
- ISSD-2246 add stylebook variables according to CSS
- ISSD-2246 Typo
- ISSD-1638 Update product cards style
- ISSD-2246 Remove blank lines
- ISSD-2246 Auto SF
- ISSD-2246 Add missing name_18n
- ISSD-2246 No longer necesary
- LPS-202082 Use proper name. After ce6a83c4b48171279442dac5b858665dff2d7cd2 tableName string and no sql is used.
- Revert "LPS-203513 Disable input when configuring non-default Display Pages"
- LPS-204884 Removes UI restrictions on robots and include-in-sitemap fields on the configuration of NON site default DPT
- LPS-204884 Removes unused language keys
- LPS-204884 BuildLang
- LPS-205121 Servlet should check the upload servlet maxsize
- LPS-146160 use correct field to check if template stageing is allowed
- LPS-146160 Should still work with private pages
- LPS-146160 Semantic versioning
- LPS-146160 Return false by default when the site is not created from a template
- LPS-197751 Update method and it's uses with new parameter and validation"
- LPS-197751 buildService
- LPS-197751 Disable read only when field is required
- LPS-204046 Add selected object folder name to the URL to correctly redirect the user back from Model Builder to the folder listing
- LPS-205361 Remove the redundant test
- LPS-205352 Update the macro to use the suitable ellipsis path
- LPS-205350 Update macro to view no filter option
- LPS-205348 Remove the unnecessary test
- LPS-201832 After LPS-196393 companyId is randomly generated, so the lower id cannot be trusted. Use createDate to sort.
- LPS-193971 extract before shorten because short first can cause the deletion of the end of a html tag
- LPS-205267 Adds new render command for edit journal article
- LPS-205267 Uses portlet builder
- LPS-205267 Uses new render command
- LPS-205267 Creates JournalEditArticleDisplayContext only once
- LPS-205267 Uses class method
- LPS-205267 Inline method
- LPS-205267 Uses local service and fetch, since we don't need to check permissions for this case
- LPS-205267 Reuse method
- LPS-205442 Update button text to match behavior
- LRAC-0 Fixing unit tests
- LPS-205571 Avoid changing the ERC when moving the article to and from the recycle bin
- LPS-205571 Adds integration test
- LPS-204749 Fix message from exception
- LPS-204749 Adding validation for some fields on ObjectConfiguration
- LPS-204749 Adding text to language.properties
- LPS-204749 Fix on message and test
- LPS-202063 Using ConfigurationProvider to tests
- LPS-202063 Fix integration tests after using ConfigurationProvider
- LPS-202063 Adding new scenario
- LPS-202063 Fix test
- LPS-204749 Fix error message on forms
- LPS-204749 Build Lang
- LPS-202063 Merge per day tests
- LPS-202063 Just one test per week is enough
- LPS-202063 Improve test
- LPS-204749 Sort
- LPS-204749 #sfme
- LPS-204749 SF
- LPS-204749 Wordsmith
- LPS-204749 Regen
- LPS-204749 Exception messages that show up in a server log don't end in periods unless there are more than 2 sentences.
- LPS-204749 Rename
- LPS-205905 Correct the steps
- LPS-204273 Unget the wrapped service only after ServiceWrapper is unwrapped.
- LPS-204273 Simplify parameter
- LPS-204273 Catch up late service.
- LPS-204273 Remove spring bean lookup, they all turn into osgi service anyway.
- LPS-204273 Semantic versioning
- LPS-204273 LPS-204274 LPS-204276 Remove unused references from DLApp wrappers
- LPS-204273 SF
- LRCI-4024 Download the portal license into OSB Faro if it is set
- LPS-205232 restore css bulider version
- LPS-205232 prep next
- LPS-205232 prep next
- LPS-205232 prep next
- LPS-205232 Update versions
- LPS-157775 extract methods of upgrade dl configurations processes to reuse several times
- LPS-157775 add new step because sometimes the configuration is not correctly upgraded, so we must redo it
- LPS-157775 only do the upgrade if there was not user changes on the new properties or the old ones are still with data
- LPS-157775 semver
- LPS-157775 extract methods to clarification
- LPS-157775 move to helper
- LPS-157775 split on several classes to make it clear that we are redoing the upgraded processes again
- LPS-157775 not needed
- LPS-157775 split method
- LPS-157775 rename
- LPS-157775 rename and refactor
- LPS-194017 Also search for nested fields when propagating fieldSet changes
- LPS-205102 Add PermissionsPortletConfigurationIcon to show the permissions option in the kebab menu and modify the weight to adapt the order
- LPS-205255 SF removes as is redundant
- LPS-205255 Take into account the utility pages
- LPS-205255 SF buy space
- LPS-205255 Adds required dependency
- LPS-205255 Provides a specific display context for the UtilityPages
- LPS-205255 Overrides isWorkflowEnabled to disabled it for utility pages
- LPS-205255 Adds required dependency
- LPS-201696 Add status property to ObjectDefintionEntityModel and ObjectDefinitionModelDocumentContributor to filter by status
- LPS-201696 Add test case filtering by status code
- LPS-201696 Apply new filter to show published Object Definitions in API Schema dropdown
- LPS-201696 Update Poshi tests
- LPS-201696 Add Indexable annotation in publishCustomObjectDefinition and publishSystemObjectDefinition
- LPS-201696 buildService
- LPS-201696 SF
- LPS-204874 Adapting test cases to current validation in the Object layer
- LPS-204874 Object name must begin with upper case
- LPS-204874 Requested changes
- LPS-204874 Retrieve and modify incorrectly removed test case
- LPS-204874 Sort
- LPS-204874 SF
- LPS-205235 Add new param languagesDropdownVisible to hide the language selector
- LPS-205235 Hide the language selector for Description and Friendly URL fields
- LPS-204273 Fix test compile
- LPS-205919 Pull out CompanyLocalService dependency
- LPS-205919 Pull out Portal dependency
- LPS-205919 Pull out GroupLocalService dependency
- LPS-205919 Pull out ConfigurationProvider dependency
- LPS-205919 JSONFactory and Language are portal-impl service, safe to use util.
- LPS-205919 Remove scr pojo service wiring design in AnalyticsCloudClient
- LPS-204267 Use model listener instead of service wrapper
- LPS-205542 Remove unused reference
- LPS-187626 Paint children of tab panel to avoid duplicated markup
- LPS-187626 Remove no needed CSS
- LPS-187626 Use a document fragment to avoid extra reflows when rendering the active tab
- LPS-187626 Manage active tab from parent Tabs component. This avoids flicker when active tab is not the first one.
- LPS-205652 Remove countries from unsupported application list
- LPS-203708 Replace form with ClayForm and add a validation for the input
- LPS-203708 Remove not needed "_" prefix for the handleSubmit
- LPS-205274 Removes distinct from select clause since editableValues is translated as CLOB in DB2 and Oracle and CLOB columns do not allow their use.
- LPS-205274 Adds a dependency to the fragment-service module Release major to 2.5.0. That must force that when LayoutClassedModelUsageUpgradeProcess is executed the plid column is already added to the FragmentEntryLink table
- LPS-205926 Remove the property
- LPS-203834 Remove unnecessary scayt sample
- LPS-203834 Apply editor config contributor CETs to CKEditor
- LPS-203834 Use improved error handling
- LPS-203834 Use API that allows future extension to customization other than `config`
- LPS-203834 Apply Editor Config Contributor CET to legacy CKEditor
- LPS-203834 Apply FF
- LPS-205397 Order builds by newest date
- LPS-205426 Take Teams out of the table filter
- LPS-205430 Add Build Names inside the chart popup
- LPS-205268 Remove usage of JSoup
- LPS-205268 No need to extend base class, use the interface
- LPS-205268 Auto SF
- LPS-205268 Add additional test
- LPS-205268 Rename
- LPS-205268 auto SF
- LPS-205268 Replace only within bounds
- LPS-205268 Accept optional query parameters at the end
- LPS-205268 Additional tests
- LPS-205268 Rename
- LPS-204379 Add npm scripts to run playwright
- LPS-204379 Ignore Playwright in standard SF
- LPS-204379 Use @liferay/npm-scripts for formatting
- LPS-204379 Update package-lock.json
- LPS-204379 SF
- LPS-204379 Always use one worker (locally and in CI)
- COMMERCE-11334 Add permission to punchout role
- LPS-205364 After LPS-202082 traces are reduced. Portal or bundle related traces are only printed if methods IndexUpdaterUtil#updatePortalIndexes and IndexUpdaterUtil#updateIndexes are called explicitely.
- LRAC-15304 Move close function call to finally statement
- LRAC-15304 No need to have try/catch if the errors have already been thrown inside try statement
- LRAC-15304 Create test
- LPS-204513 Change implementation to add permission checker to the query condition
- LPS-204513 Integration test
- LPS-204513 Check if inlineSQLChecker configuration is enable. Inline permissionChecker
- LPS-204513 Rename
- LPS-204513 Rename
- LPS-205339 Moves logic to a base class
- LPS-205339 Extends base class and call super method
- LPS-205339 Editable links can include editable elements, but cannot include drop zones or widgets
- LPS-205339 Adds new test
- LPS-205339 buildLang
- LPS-205471 delete the entry instead of updating if it already exists
- LPS-205471 End path
- LPS-205471 add test for constraint violation
- LPS-205471 SF
- LPS-205912 Add step to make case stable
- LPS-204967 prep next
- LPS-204967 prep next
- LCD-34055 mechanism so LXC(-SM) can set correct values for the default virtual instance via environment variables (without needing to touch the portal UI or database)
- LCD-34055 Wordsmith
- LCD-34055 SF
- LPS-205267 Update poshi tests since now we are using mvcRenderCommandName and /journal/edit_article instead of mvcPath and /edit_article.jsp
- LPS-168388 Add aria-current to active element
- COMMERCE-13161 added price list model view permission
- LPS-205239 Don't use deprecated method
- LPS-205239 Removes deprecated method
- LPS-205239 Removes unused method
- LPS-205239 Simplify using a ServiceTrackerList since className is always User
- LPS-205239 Update usages
- LPS-205239 baseline
- LPS-201144 Make the Learning Message Resource Key More Specific and Add a New One
- LPS-205365 Add workspace sample for editor config contributor CET
- LPS-205365 Apply new EditorTransformer API to the workspace sample
- LPS-205365 please add a description that matches the existing descriptions
- COMMERCE-13087 Remove unused @Reference
- COMMERCE-13088 Remove unused @Reference
- COMMERCE-13089 Remove unused @Reference
- COMMERCE-13090 Remove unused @Reference
- COMMERCE-13091 Remove unused @Reference
- COMMERCE-13092 Remove unused @Reference
- COMMERCE-13093 Remove unused @Reference
- COMMERCE-13094 Remove unused @Reference
- COMMERCE-13095 Remove unused @Reference
- COMMERCE-13096 Remove unused @Reference
- COMMERCE-13097 Remove unused @Reference
- COMMERCE-13098 Remove unused @Reference
- COMMERCE-13099 Remove unused @Reference
- COMMERCE-13100 Remove unused @Reference
- COMMERCE-13101 Remove unused @Reference
- COMMERCE-13102 Remove unused @Reference
- COMMERCE-13103 Remove unused @Reference
- COMMERCE-13104 Remove unused @Reference
- COMMERCE-13105 Remove unused @Reference
- COMMERCE-13106 Remove unused @Reference
- COMMERCE-13107 Remove unused @Reference
- COMMERCE-13108 Remove unused @Reference
- COMMERCE-13109 Remove unused @Reference
- COMMERCE-13110 Remove unused @Reference
- COMMERCE-13112 Remove unused @Reference
- COMMERCE-13113 Remove unused @Reference
- COMMERCE-13114 Remove unused @Reference
- COMMERCE-13115 Remove unused @Reference
- COMMERCE-13116 Remove unused @Reference
- COMMERCE-13117 Remove unused @Reference
- COMMERCE-13118 Remove unused @Reference
- COMMERCE-13119 Remove unused @Reference
- COMMERCE-13120 Remove unused @Reference
- COMMERCE-13121 Remove unused @Reference
- COMMERCE-13122 Remove unused @Reference
- COMMERCE-13123 Remove unused @Reference
- COMMERCE-13124 Remove unused @Reference
- COMMERCE-13125 Remove unused @Reference
- COMMERCE-13126 Remove unused @Reference
- COMMERCE-13127 Remove unused @Reference
- COMMERCE-13128 Remove unused @Reference
- COMMERCE-13129 Remove unused @Reference
- COMMERCE-13130 Remove unused @Reference
- COMMERCE-13131 Remove unused @Reference
- COMMERCE-13132 Remove unused @Reference
- COMMERCE-13133 Remove unused @Reference
- COMMERCE-13134 Remove unused @Reference
- COMMERCE-13135 Remove unused @Reference
- COMMERCE-13136 Remove unused @Reference
- COMMERCE-12385 Create a new client extensions
- COMMERCE-12385 Follow up PR
- COMMERCE-12385 Sync
- COMMERCE-12385 Add -
- COMMERCE-12385 Consistency
- COMMERCE-12385 Rename
- COMMERCE-12385 Not used
- COMMERCE-12385 Make the caller more robust and make the API simpler without requiring a certain type of response
- COMMERCE-12385 Only return what can be changed
- LPS-206040 Move IndexNameBuilder to base class
- LPS-206040 Move getIndexMappingFileName() impl to base class
- LPS-206040 Move getIndexName() impl to base class
- LPS-206040 RecommendationIndexer is an internal interface, it should not be registered as osgi service, because there will be no way for outside code to consume or register new service of this type. Register it as osgi service by SCR just for wiring is an abuse of DS.
- LPS-206040 SF
- Revert "LPS-204283 Remove unused references from AM"
- LPS-205910 Remove unused Reference field _npmResolver as usage was removed in 8dbd5c4cde942299262a114dce4001665b655141
- LPS-204864 Add case and path to assert can configure required vocabulary in an asset library on the site connected
- LPS-204864 Add case to disconnect and connect the site to the Asset Library when selecting 'Required in This Asset Library and Its Connected Sites'
- COMMERCE-13183 fixed locator
- LPS-204260 Remove reference to workflow in mb upgrade
- LPS-204278 Remove CtStoreFactory reference from DLServiceVerifyProcess
- LPS-204253 Remove unused reference from assets
- LPS-205105 This only works on ItemStack
- LPS-205105 Disable the node only if it has no children
- LPS-205105 Improve disabled items handle
- LPS-205105 Apply the same to onKeyDown
- LPS-205289 Add method to click Fit View button
- LPS-205289 Add method to click Toggle Sidebars button
- LPS-205289 Make sure 'can create relationship by dragging node handles' test makes all nodes and fields visible before interacting with them
- LPS-205289 Rename method to getObjectDefinitionNodeRelationshipHandle
- LPS-205289 Sort
- LPS-205289 Rename Objects playwright test folder from object to object-web
- LPS-206019 Fixed Build metrics bar and columns of table
- LPS-206025 Fixed behavior of multiselect of filters to close with Escape key
- LPS-206101 - Refactor. Revert z-index change to prevent displaying close icon twice
- LPS-205317 Missing companyId on regular expression
- LPS-196524 breaking changes amend
- LPS-204257 Removes view count reference for asset service
- LPS-204979 Disable autoCrop and limit the first zoom to 100%
- LPS-204979 Use mix, max, step on zoom instead of zoom fixed steps and delete the zoom percentage
- LPS-204979 Disable the zoom UI in advance based on the next zoom
- LPS-203342 Change labels in the AI Creator modal
- LPS-203342 buildLang
- LPS-203342 SF
- LPS-201696 Auto SF
- LPS-205240 Create save buttons components
- LPS-205240 Include component to replace buttons
- LPS-205240 Include the component only if the FF is enabled
- LPS-205240 Don't do anything if the ff is enabled since this will be handled from other place
- LPS-206078 Add step to wait for input editable
- LPS-205593 Avoid NPE
- LPS-205593 Integration test: labelMap null case
- LPS-205593 SF
- LPS-205268 Remove generic type
- LPS-204513 Fix rename
- ISSD-2205 Make Side nav to support small screen view
- ISSD-2205 SF
- ISSD-2205 improve some CSS responsiveness
- LPS-206077 Modify case to adapt new behavior
- LPS-205266 When a category or tag is selected ensure that the search results are filtered based on them
- LPS-205266 Do not disable the filter drop down or select 'All' when filtering based on category or tag
- LPS-205902 Make onKeyPress event for Clear link
- LPS-205906 Unused configuration pid
- LPS-205906 AssetPublisherCustomizer is an internal interface, it should not be registered as osgi service, because there will be no way for outside code to consume or register new service of this type. Register it as osgi service by SCR just for wiring is an abuse of DS.
- LRAC-15363 fix empty attributes
- LRAC-15363 fix possible NPE
- LPS-190069 Update countries follow the ISO-3166
- LPS-190069 Update regions follow the ISO-3166
- LPS-190069 Add module dependencies
- LPS-190069 Upgrade process
- LPS-190069 Update tests
- LPS-190069 Sublime sort
- LPS-190069 Use i instead of j
- LPS-190069 Move to its own method
- LPS-206100 Get the data-languageid if the data-value does not exist
- LPS-206082 Modify case to make it stable
- LPS-202333 (change-tracking-web) Add verification to assure that the redirect is correct
- LPS-202814 Update test and remove workaround for LPS-202333
- WIP
