### PR TITLE
LPD-92211 Add missing dependencies to osb-faro-web package.json

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/package.json
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/package.json
@@ -100,6 +100,7 @@
 		"@types/react-transition-group": "^4.4.0",
 		"@types/recharts": "^2.0.0",
 		"@types/redux": "^3.6.0",
+		"@types/uuid": "^9.0.8",
 		"@typescript-eslint/eslint-plugin": "^5.62.0",
 		"@typescript-eslint/parser": "^5.62.0",
 		"autobind-decorator": "^2.1.0",

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/package.json
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/package.json
@@ -89,6 +89,7 @@
 		"@testing-library/react": "^13.4.0",
 		"@types/autobind-decorator": "^2.1.0",
 		"@types/classnames": "^2.2.8",
+		"@types/d3": "^7.4.3",
 		"@types/jest": "^29.5.0",
 		"@types/lodash": "^4.14.134",
 		"@types/prop-types": "^15.7.1",

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/package.json
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/package.json
@@ -27,6 +27,7 @@
 		"@clayui/loading-indicator": "^3.161.0",
 		"@clayui/modal": "^3.161.0",
 		"@clayui/multi-select": "^3.161.0",
+		"@clayui/multi-step-nav": "^3.161.0",
 		"@clayui/navigation-bar": "^3.161.0",
 		"@clayui/pagination-bar": "^3.161.0",
 		"@clayui/panel": "^3.161.0",

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/download-report/__tests__/useDownloadCSV.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/download-report/__tests__/useDownloadCSV.ts
@@ -1,6 +1,8 @@
+jest.unmock('react-dom');
+
 import {CSVType, useDownloadCSV} from '../utils';
 import {RangeKeyTimeRanges} from 'shared/util/constants';
-import {renderHook} from '@testing-library/react-hooks';
+import {renderHook} from '@testing-library/react';
 
 jest.mock('react-router-dom', () => ({
 	...jest.requireActual('react-router-dom'),

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/__tests__/useQueryParams.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/__tests__/useQueryParams.ts
@@ -1,4 +1,6 @@
-import {renderHook} from '@testing-library/react-hooks';
+jest.unmock('react-dom');
+
+import {renderHook} from '@testing-library/react';
 import {useLocation} from 'react-router-dom';
 import {useQueryParams} from '../useQueryParams';
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/yarn.lock
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/yarn.lock
@@ -2235,22 +2235,100 @@
   dependencies:
     "@types/node" "*"
 
-"@types/d3-array@^3.0.3":
+"@types/d3-array@*", "@types/d3-array@^3.0.3":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-3.2.2.tgz#e02151464d02d4a1b44646d0fcdb93faf88fde8c"
   integrity sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==
+
+"@types/d3-axis@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-axis/-/d3-axis-3.0.6.tgz#e760e5765b8188b1defa32bc8bb6062f81e4c795"
+  integrity sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-brush@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-brush/-/d3-brush-3.0.6.tgz#c2f4362b045d472e1b186cdbec329ba52bdaee6c"
+  integrity sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-chord@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-chord/-/d3-chord-3.0.6.tgz#1706ca40cf7ea59a0add8f4456efff8f8775793d"
+  integrity sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==
 
 "@types/d3-color@*":
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.1.3.tgz#368c961a18de721da8200e80bf3943fb53136af2"
   integrity sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==
 
-"@types/d3-ease@^3.0.0":
+"@types/d3-contour@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-contour/-/d3-contour-3.0.6.tgz#9ada3fa9c4d00e3a5093fed0356c7ab929604231"
+  integrity sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==
+  dependencies:
+    "@types/d3-array" "*"
+    "@types/geojson" "*"
+
+"@types/d3-delaunay@*":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz#185c1a80cc807fdda2a3fe960f7c11c4a27952e1"
+  integrity sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==
+
+"@types/d3-dispatch@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz#ef004d8a128046cfce434d17182f834e44ef95b2"
+  integrity sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==
+
+"@types/d3-drag@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-drag/-/d3-drag-3.0.7.tgz#b13aba8b2442b4068c9a9e6d1d82f8bcea77fc02"
+  integrity sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-dsv@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-dsv/-/d3-dsv-3.0.7.tgz#0a351f996dc99b37f4fa58b492c2d1c04e3dac17"
+  integrity sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==
+
+"@types/d3-ease@*", "@types/d3-ease@^3.0.0":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@types/d3-ease/-/d3-ease-3.0.2.tgz#e28db1bfbfa617076f7770dd1d9a48eaa3b6c51b"
   integrity sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==
 
-"@types/d3-interpolate@^3.0.1":
+"@types/d3-fetch@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-fetch/-/d3-fetch-3.0.7.tgz#c04a2b4f23181aa376f30af0283dbc7b3b569980"
+  integrity sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==
+  dependencies:
+    "@types/d3-dsv" "*"
+
+"@types/d3-force@*":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@types/d3-force/-/d3-force-3.0.10.tgz#6dc8fc6e1f35704f3b057090beeeb7ac674bff1a"
+  integrity sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==
+
+"@types/d3-format@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-format/-/d3-format-3.0.4.tgz#b1e4465644ddb3fdf3a263febb240a6cd616de90"
+  integrity sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==
+
+"@types/d3-geo@*":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-geo/-/d3-geo-3.1.0.tgz#b9e56a079449174f0a2c8684a9a4df3f60522440"
+  integrity sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==
+  dependencies:
+    "@types/geojson" "*"
+
+"@types/d3-hierarchy@*":
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz#6023fb3b2d463229f2d680f9ac4b47466f71f17b"
+  integrity sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==
+
+"@types/d3-interpolate@*", "@types/d3-interpolate@^3.0.1":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz#412b90e84870285f2ff8a846c6eb60344f12a41c"
   integrity sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==
@@ -2262,29 +2340,110 @@
   resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-3.1.1.tgz#f632b380c3aca1dba8e34aa049bcd6a4af23df8a"
   integrity sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==
 
-"@types/d3-scale@^4.0.2":
+"@types/d3-polygon@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-polygon/-/d3-polygon-3.0.2.tgz#dfae54a6d35d19e76ac9565bcb32a8e54693189c"
+  integrity sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==
+
+"@types/d3-quadtree@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz#d4740b0fe35b1c58b66e1488f4e7ed02952f570f"
+  integrity sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==
+
+"@types/d3-random@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-random/-/d3-random-3.0.3.tgz#ed995c71ecb15e0cd31e22d9d5d23942e3300cfb"
+  integrity sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==
+
+"@types/d3-scale-chromatic@*":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz#dc6d4f9a98376f18ea50bad6c39537f1b5463c39"
+  integrity sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==
+
+"@types/d3-scale@*", "@types/d3-scale@^4.0.2":
   version "4.0.9"
   resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.9.tgz#57a2f707242e6fe1de81ad7bfcccaaf606179afb"
   integrity sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==
   dependencies:
     "@types/d3-time" "*"
 
-"@types/d3-shape@^3.1.0":
+"@types/d3-selection@*":
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@types/d3-selection/-/d3-selection-3.0.11.tgz#bd7a45fc0a8c3167a631675e61bc2ca2b058d4a3"
+  integrity sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==
+
+"@types/d3-shape@*", "@types/d3-shape@^3.1.0":
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-3.1.8.tgz#d1516cc508753be06852cd06758e3bb54a22b0e3"
   integrity sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==
   dependencies:
     "@types/d3-path" "*"
 
+"@types/d3-time-format@*":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-time-format/-/d3-time-format-4.0.3.tgz#d6bc1e6b6a7db69cccfbbdd4c34b70632d9e9db2"
+  integrity sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==
+
 "@types/d3-time@*", "@types/d3-time@^3.0.0":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.4.tgz#8472feecd639691450dd8000eb33edd444e1323f"
   integrity sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==
 
-"@types/d3-timer@^3.0.0":
+"@types/d3-timer@*", "@types/d3-timer@^3.0.0":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@types/d3-timer/-/d3-timer-3.0.2.tgz#70bbda77dc23aa727413e22e214afa3f0e852f70"
   integrity sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==
+
+"@types/d3-transition@*":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-transition/-/d3-transition-3.0.9.tgz#1136bc57e9ddb3c390dccc9b5ff3b7d2b8d94706"
+  integrity sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-zoom@*":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@types/d3-zoom/-/d3-zoom-3.0.8.tgz#dccb32d1c56b1e1c6e0f1180d994896f038bc40b"
+  integrity sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==
+  dependencies:
+    "@types/d3-interpolate" "*"
+    "@types/d3-selection" "*"
+
+"@types/d3@^7.4.3":
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/@types/d3/-/d3-7.4.3.tgz#d4550a85d08f4978faf0a4c36b848c61eaac07e2"
+  integrity sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==
+  dependencies:
+    "@types/d3-array" "*"
+    "@types/d3-axis" "*"
+    "@types/d3-brush" "*"
+    "@types/d3-chord" "*"
+    "@types/d3-color" "*"
+    "@types/d3-contour" "*"
+    "@types/d3-delaunay" "*"
+    "@types/d3-dispatch" "*"
+    "@types/d3-drag" "*"
+    "@types/d3-dsv" "*"
+    "@types/d3-ease" "*"
+    "@types/d3-fetch" "*"
+    "@types/d3-force" "*"
+    "@types/d3-format" "*"
+    "@types/d3-geo" "*"
+    "@types/d3-hierarchy" "*"
+    "@types/d3-interpolate" "*"
+    "@types/d3-path" "*"
+    "@types/d3-polygon" "*"
+    "@types/d3-quadtree" "*"
+    "@types/d3-random" "*"
+    "@types/d3-scale" "*"
+    "@types/d3-scale-chromatic" "*"
+    "@types/d3-selection" "*"
+    "@types/d3-shape" "*"
+    "@types/d3-time" "*"
+    "@types/d3-time-format" "*"
+    "@types/d3-timer" "*"
+    "@types/d3-transition" "*"
+    "@types/d3-zoom" "*"
 
 "@types/eslint-scope@^3.7.7":
   version "3.7.7"
@@ -2345,6 +2504,11 @@
     "@types/express-serve-static-core" "^4.17.33"
     "@types/qs" "*"
     "@types/serve-static" "^1"
+
+"@types/geojson@*":
+  version "7946.0.16"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.16.tgz#8ebe53d69efada7044454e3305c19017d97ced2a"
+  integrity sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==
 
 "@types/graceful-fs@^4.1.3":
   version "4.1.9"

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/yarn.lock
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/yarn.lock
@@ -2646,6 +2646,11 @@
   resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz#60be8d21baab8c305132eb9cb912ed497852aadc"
   integrity sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==
 
+"@types/uuid@^9.0.8":
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
+  integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
+
 "@types/ws@^8.5.5":
   version "8.18.1"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.18.1.tgz#48464e4bf2ddfd17db13d845467f6070ffea4aa9"

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/yarn.lock
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/yarn.lock
@@ -1091,6 +1091,16 @@
     classnames "2.3.1"
     warning "^4.0.3"
 
+"@clayui/button@^3.163.0":
+  version "3.163.0"
+  resolved "https://registry.yarnpkg.com/@clayui/button/-/button-3.163.0.tgz#4d73e8b8cfd5e2ee22d107b47caf52983b70f5ce"
+  integrity sha512-s80D71zRVRDQ3HP1VMHoOXUlEwTmIjDdv61kvXPApI7bVVp3u7gQcyjMS5GRQiYmHKprHCNOtxO1MyWCpbc0aQ==
+  dependencies:
+    "@clayui/icon" "^3.163.0"
+    "@clayui/loading-indicator" "^3.163.0"
+    classnames "2.3.1"
+    warning "^4.0.3"
+
 "@clayui/core@^3.161.0":
   version "3.161.0"
   resolved "https://registry.yarnpkg.com/@clayui/core/-/core-3.161.0.tgz#f48414f67aa914a6874e3eba83bceb96a8aa2cfe"
@@ -1118,6 +1128,33 @@
     react-transition-group "^4.4.1"
     warning "^4.0.3"
 
+"@clayui/core@^3.163.0":
+  version "3.163.0"
+  resolved "https://registry.yarnpkg.com/@clayui/core/-/core-3.163.0.tgz#b96293ea787fc0dfb4da9b4984ff779a4f29b2cf"
+  integrity sha512-ZXbMoy9tti4ErpXTDhc3kw0+BvwqirFoxuDODFfLbOz/boJIIwBos/+emrWlxk2Vee/inkzOUrpsxwgBHsENXg==
+  dependencies:
+    "@clayui/button" "^3.163.0"
+    "@clayui/data-provider" "^3.163.0"
+    "@clayui/form" "^3.163.0"
+    "@clayui/icon" "^3.163.0"
+    "@clayui/label" "^3.163.0"
+    "@clayui/layout" "^3.163.0"
+    "@clayui/link" "^3.163.0"
+    "@clayui/loading-indicator" "^3.163.0"
+    "@clayui/modal" "^3.163.0"
+    "@clayui/provider" "^3.163.0"
+    "@clayui/shared" "^3.163.0"
+    "@clayui/table" "^3.163.0"
+    "@clayui/tooltip" "^3.163.0"
+    "@tanstack/react-virtual" "3.0.0-beta.54"
+    aria-hidden "^1.2.2"
+    classnames "2.3.1"
+    fuzzy "^0.1.3"
+    react-dnd "11.1.1"
+    react-dnd-html5-backend "11.1.1"
+    react-transition-group "^4.4.1"
+    warning "^4.0.3"
+
 "@clayui/css@^3.161.0":
   version "3.161.0"
   resolved "https://registry.yarnpkg.com/@clayui/css/-/css-3.161.0.tgz#f55bb1471af4489814d468735ea72e8c6b96c907"
@@ -1133,6 +1170,16 @@
     fast-json-stable-stringify "^2.1.0"
     warning "^4.0.3"
 
+"@clayui/data-provider@^3.163.0":
+  version "3.163.0"
+  resolved "https://registry.yarnpkg.com/@clayui/data-provider/-/data-provider-3.163.0.tgz#10ec501259b65fc61f8db11b9753b41af30ebe36"
+  integrity sha512-tGgtlygpXOUuZ83DdKqSwvAzsxPTZAQbuURC8lS2KEaNzwinfOj5CrGfhbmo+42VXUT+EuCZsmgJFZUE/LKEUw==
+  dependencies:
+    "@clayui/provider" "^3.163.0"
+    "@clayui/shared" "^3.163.0"
+    fast-json-stable-stringify "^2.1.0"
+    warning "^4.0.3"
+
 "@clayui/drop-down@^3.161.0":
   version "3.161.0"
   resolved "https://registry.yarnpkg.com/@clayui/drop-down/-/drop-down-3.161.0.tgz#df3f810ba3c6119cf6b205d0b0d4a9e64f2b3f3d"
@@ -1144,6 +1191,21 @@
     "@clayui/icon" "^3.161.0"
     "@clayui/link" "^3.161.0"
     "@clayui/shared" "^3.161.0"
+    classnames "2.3.1"
+    react-transition-group "^4.4.1"
+    warning "^4.0.3"
+
+"@clayui/drop-down@^3.163.0":
+  version "3.163.0"
+  resolved "https://registry.yarnpkg.com/@clayui/drop-down/-/drop-down-3.163.0.tgz#b7cd1e20c3cfe8808689339d8e1e6bc7f8a15ca9"
+  integrity sha512-Rfploor1w98rh1U74yaUqFgGMxG50sZnzsgjjZmH5KnAINJgSNna4c4zNttVJGfczjPnI3VXWxbg0mBxA4YtXA==
+  dependencies:
+    "@clayui/button" "^3.163.0"
+    "@clayui/core" "^3.163.0"
+    "@clayui/form" "^3.163.0"
+    "@clayui/icon" "^3.163.0"
+    "@clayui/link" "^3.163.0"
+    "@clayui/shared" "^3.163.0"
     classnames "2.3.1"
     react-transition-group "^4.4.1"
     warning "^4.0.3"
@@ -1165,10 +1227,28 @@
     "@clayui/shared" "^3.161.0"
     classnames "2.3.1"
 
+"@clayui/form@^3.163.0":
+  version "3.163.0"
+  resolved "https://registry.yarnpkg.com/@clayui/form/-/form-3.163.0.tgz#c5f0fe4ed3134569a1cdf0854ef0e267829c7b5c"
+  integrity sha512-wJ1Bqb8ouzVJd8aR42qZK6giG2TLbdcKD9WPBU32zNZ7qlsXu1mtXxAiSf+uMEO5b9OHIyNnP/rdtir8rRqYtw==
+  dependencies:
+    "@clayui/button" "^3.163.0"
+    "@clayui/icon" "^3.163.0"
+    "@clayui/shared" "^3.163.0"
+    classnames "2.3.1"
+
 "@clayui/icon@^3.161.0":
   version "3.161.0"
   resolved "https://registry.yarnpkg.com/@clayui/icon/-/icon-3.161.0.tgz#6c18ca4038484891e3324172c771e4a69192ca7a"
   integrity sha512-/7Wbe4zROdLr2mGC07WIK73owhWupU4X/HE4hjfr8WfhD8THUl01PqPSEG5BU84m3vwliCGagN9DQWbHrnaKqA==
+  dependencies:
+    classnames "2.3.1"
+    warning "^4.0.3"
+
+"@clayui/icon@^3.163.0":
+  version "3.163.0"
+  resolved "https://registry.yarnpkg.com/@clayui/icon/-/icon-3.163.0.tgz#5fb90f3a58cce3186f3157388745d376a979fd84"
+  integrity sha512-0E3Nba4gXGYFcKDG1gs8j4AvadFAlBCxj8LFkJr8rwV3CMZFesZBSw397XoQoK8lJuJ3cNp+WYdHggAVS88ong==
   dependencies:
     classnames "2.3.1"
     warning "^4.0.3"
@@ -1182,6 +1262,15 @@
     "@clayui/link" "^3.161.0"
     classnames "2.3.1"
 
+"@clayui/label@^3.163.0":
+  version "3.163.0"
+  resolved "https://registry.yarnpkg.com/@clayui/label/-/label-3.163.0.tgz#53b89962308e3c9a2b6be09f15316fcd5dd37b31"
+  integrity sha512-pC7aX2ihLWHOaKOgTIESK+uCSlym57+9VEQ33oypm6aFfFbXMnBPkstkfwm7iiHU+UG5VabI8wf3v05MLNNr8w==
+  dependencies:
+    "@clayui/icon" "^3.163.0"
+    "@clayui/link" "^3.163.0"
+    classnames "2.3.1"
+
 "@clayui/layout@^3.161.0":
   version "3.161.0"
   resolved "https://registry.yarnpkg.com/@clayui/layout/-/layout-3.161.0.tgz#74e5c8b3c020098e5950310acd42bde6638a55ee"
@@ -1190,10 +1279,25 @@
     classnames "2.3.1"
     warning "^4.0.3"
 
+"@clayui/layout@^3.163.0":
+  version "3.163.0"
+  resolved "https://registry.yarnpkg.com/@clayui/layout/-/layout-3.163.0.tgz#50de6d85a173c37fbf4d5335bfad37e1c38cc66e"
+  integrity sha512-Dzw+j8c2H7mfmrqtxuP4tnThmACItXlAiBDWSytvkZSrNDOyVsYT/CQvkfRXNJQLe2lq5CZz+zF8lFaQw8PDzg==
+  dependencies:
+    classnames "2.3.1"
+    warning "^4.0.3"
+
 "@clayui/link@^3.161.0":
   version "3.161.0"
   resolved "https://registry.yarnpkg.com/@clayui/link/-/link-3.161.0.tgz#2867a38696f5b9c0159cfa28879bae8044e3cad2"
   integrity sha512-M5bC5sleTcNldj9ErlCO9I4f3l9U8OPQxbswqpV8l6kisLaleUOLtSNdZtCfAdEE0Rq/nrC+BDWbaBfDF6HRkQ==
+  dependencies:
+    classnames "2.3.1"
+
+"@clayui/link@^3.163.0":
+  version "3.163.0"
+  resolved "https://registry.yarnpkg.com/@clayui/link/-/link-3.163.0.tgz#6ddd509e3ccf428a3e9ceff1c7b516ca4ef7ff65"
+  integrity sha512-oCUICfAtLfVrQi9RvRtwq7kIfyfOv25MNPnjGO1cptARycCLAqa7AKx5s6Xt1P600la+zGW2oMXNpjIRGniJIQ==
   dependencies:
     classnames "2.3.1"
 
@@ -1220,6 +1324,13 @@
   dependencies:
     classnames "2.3.1"
 
+"@clayui/loading-indicator@^3.163.0":
+  version "3.163.0"
+  resolved "https://registry.yarnpkg.com/@clayui/loading-indicator/-/loading-indicator-3.163.0.tgz#e3117a02e6391f606934cd2ab402816ebdc288be"
+  integrity sha512-qAxfqLcKfiU35sHJWQkstt4ajRdHZwM1jFLQhoMFUw98Ktu//8t1akrLaP+SWP2KMPgQkj3S6bK1yiiLiLbHPA==
+  dependencies:
+    classnames "2.3.1"
+
 "@clayui/modal@^3.161.0":
   version "3.161.0"
   resolved "https://registry.yarnpkg.com/@clayui/modal/-/modal-3.161.0.tgz#e2a569d1503e16b1cc091de753494473a8d827a1"
@@ -1228,6 +1339,18 @@
     "@clayui/button" "^3.161.0"
     "@clayui/icon" "^3.161.0"
     "@clayui/shared" "^3.161.0"
+    aria-hidden "^1.2.2"
+    classnames "2.3.1"
+    warning "^4.0.3"
+
+"@clayui/modal@^3.163.0":
+  version "3.163.0"
+  resolved "https://registry.yarnpkg.com/@clayui/modal/-/modal-3.163.0.tgz#7ab79f3c186c11fa61b6dcbf07fb02f9375906a0"
+  integrity sha512-yvmr0l01V73vlwnqGT9UYgxiIPQDoUx3I3b9gCtO3I2zXt5LwdhnIU8R/TYsutljXumTsQbZaBDqPLMcojUqbw==
+  dependencies:
+    "@clayui/button" "^3.163.0"
+    "@clayui/icon" "^3.163.0"
+    "@clayui/shared" "^3.163.0"
     aria-hidden "^1.2.2"
     classnames "2.3.1"
     warning "^4.0.3"
@@ -1247,6 +1370,16 @@
     "@clayui/shared" "^3.161.0"
     classnames "2.3.1"
     fuzzy "^0.1.3"
+
+"@clayui/multi-step-nav@^3.161.0":
+  version "3.163.0"
+  resolved "https://registry.yarnpkg.com/@clayui/multi-step-nav/-/multi-step-nav-3.163.0.tgz#089561100eedc018487d757b1b5dd7da53e2aa75"
+  integrity sha512-7ZnB0bbbMfcgz37UcKMm9aufljIcxdA5rFGJ2NufWEBc+WiN3fib3Qo7aytKZnr1/zUQPeD/8jP+WXhdhZfsHg==
+  dependencies:
+    "@clayui/drop-down" "^3.163.0"
+    "@clayui/icon" "^3.163.0"
+    "@clayui/shared" "^3.163.0"
+    classnames "2.3.1"
 
 "@clayui/navigation-bar@^3.161.0":
   version "3.161.0"
@@ -1315,6 +1448,13 @@
   dependencies:
     "@clayui/icon" "^3.161.0"
 
+"@clayui/provider@^3.163.0":
+  version "3.163.0"
+  resolved "https://registry.yarnpkg.com/@clayui/provider/-/provider-3.163.0.tgz#aa07b05a6b4eb688a282052ffb0cab8375baaf5d"
+  integrity sha512-6KErTuK6BLLdQN1X78MyBFGKzqjdMaE6umPzDBHb1KQQxLlJt26AJKQz0pS66IFqksG4Ebl/EnkbZkqcOItwag==
+  dependencies:
+    "@clayui/icon" "^3.163.0"
+
 "@clayui/shared@^3.161.0":
   version "3.161.0"
   resolved "https://registry.yarnpkg.com/@clayui/shared/-/shared-3.161.0.tgz#d2d8ede9c4127c9fbc8b9e43f098412f1c74cf99"
@@ -1323,6 +1463,19 @@
     "@clayui/button" "^3.161.0"
     "@clayui/link" "^3.161.0"
     "@clayui/provider" "^3.161.0"
+    aria-hidden "^1.2.2"
+    classnames "2.3.1"
+    dom-align "^1.12.2"
+    warning "^4.0.3"
+
+"@clayui/shared@^3.163.0":
+  version "3.163.0"
+  resolved "https://registry.yarnpkg.com/@clayui/shared/-/shared-3.163.0.tgz#ff7a4ebc3274930bea8c19670a434fc1a286dc31"
+  integrity sha512-WYkY5NU0tc8Fdg1WFvWC/aBAw4cGhYSyXcp1iMWS1WXr7RsQdMx6AZbLTrSttRiu3jkD+JVbK2oQWRWL7FHUNQ==
+  dependencies:
+    "@clayui/button" "^3.163.0"
+    "@clayui/link" "^3.163.0"
+    "@clayui/provider" "^3.163.0"
     aria-hidden "^1.2.2"
     classnames "2.3.1"
     dom-align "^1.12.2"
@@ -1339,6 +1492,13 @@
   version "3.161.0"
   resolved "https://registry.yarnpkg.com/@clayui/table/-/table-3.161.0.tgz#83ee84e6480628a87bc49cbc80f3f3c125ac299e"
   integrity sha512-4nJE8TR78qmeTMRKrCH4UbE0h06VnRbuIP0i7FvCUN73395ws3X2iIZH39HkWX8qnEtjgF6/fr67Z3A7eRCDMA==
+  dependencies:
+    classnames "2.3.1"
+
+"@clayui/table@^3.163.0":
+  version "3.163.0"
+  resolved "https://registry.yarnpkg.com/@clayui/table/-/table-3.163.0.tgz#f2f8057047fdea2f071ff17ea788d0373e7a7822"
+  integrity sha512-igiVsk4mSwNFWp2t3uakXs+V/uO1CPpBJJHivpZLSiyNf6owp4z2h8BTn1IW5Fy6DsXLySDAmqvVcq8qcoSK6Q==
   dependencies:
     classnames "2.3.1"
 
@@ -1367,6 +1527,16 @@
   integrity sha512-NQN5yL/isbNVU6dCD8m+ESVbH/Y3053W2Ji+0GwFlau/z1RnPjbEIq6ZhjRzmH3X78mMdvxKZ8O94H0aT71oJA==
   dependencies:
     "@clayui/shared" "^3.161.0"
+    classnames "2.3.1"
+    dom-align "^1.12.2"
+    warning "^4.0.3"
+
+"@clayui/tooltip@^3.163.0":
+  version "3.163.0"
+  resolved "https://registry.yarnpkg.com/@clayui/tooltip/-/tooltip-3.163.0.tgz#ca83d3b79256447092574da3c299b63ecb86b2c1"
+  integrity sha512-eBK5sIexywkZtJKiwWp6lpJ5NgispjGa35O4oFkSBSQKdARl0Vh2m1SIJIK23nthJGCYYCXEpYrBzTSbbiAI5Q==
+  dependencies:
+    "@clayui/shared" "^3.163.0"
     classnames "2.3.1"
     dom-align "^1.12.2"
     warning "^4.0.3"


### PR DESCRIPTION
Fixes several latent bugs in `osb-faro-web` that surface only on a fresh CI checkout (locally everything passes because TypeScript/Node resolution walks up the directory tree and finds matching packages under `modules/node_modules/`, left behind by sibling modules).

**Missing dependencies added to `package.json`:**

- `@types/uuid@^9.0.8` (devDependencies) — for `import {v4} from 'uuid'`
- `@types/d3@^7.4.3` (devDependencies) — for `import * as d3 from 'd3'` and `import {utcFormat} from 'd3'`
- `@clayui/multi-step-nav@^3.161.0` (dependencies) — imported by `LifecycleStatus.tsx` (introduced in commit 501882c, LPD-87699) but never declared

**Migration (instead of installing a deprecated package):**

- `useDownloadCSV.ts` and `useQueryParams.ts` were importing `renderHook` from `@testing-library/react-hooks`, which is deprecated since React 18 and not declared as a devDep. Migrated to `renderHook` from `@testing-library/react` (already a devDep). Required `jest.unmock('react-dom')` in each test because `setup.js` globally mocks `react-dom` and the v13 `renderHook` needs the real DOM (unlike `react-hooks` v8 which used `react-test-renderer`).

Other runtime deps imported from the source may share the same latent bug; will be addressed in follow-up commits if subsequent CI runs reveal them.

Jira: https://liferay.atlassian.net/browse/LPD-92211