### PR TITLE
LPD-92290 Prevent getInitials from crashing when name is null

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/util.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/util.js
@@ -1,6 +1,7 @@
 import {
 	formatStringToLowercase,
 	getAlignPosition,
+	getInitials,
 	getPercentage,
 	getRangeSelectorsFromQuery,
 	getSafeDecodedURIComponent,
@@ -62,6 +63,28 @@ describe('util', () => {
 			expect(getAlignPosition(source, target, 'bottom')).toEqual(
 				'bottom'
 			);
+		});
+	});
+
+	describe('getInitials', () => {
+		it('should return uppercased initials for a full name', () => {
+			expect(getInitials('Adriano Interaminense')).toEqual('AI');
+		});
+
+		it('should cap the result at three initials', () => {
+			expect(getInitials('Foo Bar Baz Qux')).toEqual('FBB');
+		});
+
+		it('should return an empty string when name is undefined', () => {
+			expect(getInitials(undefined)).toEqual('');
+		});
+
+		it('should return an empty string when name is null', () => {
+			expect(getInitials(null)).toEqual('');
+		});
+
+		it('should return an empty string when no argument is provided', () => {
+			expect(getInitials()).toEqual('');
 		});
 	});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/util.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/util.ts
@@ -261,8 +261,8 @@ export const mergeRef =
 			}
 		});
 
-export function getInitials(name = '') {
-	const nameArray = name.split(' ', 3);
+export function getInitials(name: string | null | undefined = '') {
+	const nameArray = (name ?? '').split(' ', 3);
 
 	return nameArray
 		.reduce((acc, val) => acc + val.substring(0, 1), '')


### PR DESCRIPTION
## Summary

- Coalesce `null` to an empty string in `getInitials`, so the workspace landing page no longer crashes when the current user record has `name: null`.
- Add unit tests covering `undefined`, `null`, and missing-argument inputs, plus the typical full-name case.

## Context

Jira: [LPD-92290](https://liferay.atlassian.net/browse/LPD-92290)

`getInitials(name = '')` relied on a default parameter, which only substitutes `undefined`, not `null`. The `User` Immutable Record defaults `name` to `''`, but the constructor preserves `null` when the backend returns it, so the sidebar's `UserDropdown` was calling `getInitials(null)` and `name.split(' ', 3)` threw `TypeError: Cannot read properties of null (reading 'split')`, blanking the entire workspace UI.

## Test plan

- [x] `yarn jest --testPathPattern="shared/util/__tests__/util.js"` — 54/54 pass (5 new assertions for `getInitials`).
- [x] `gradlew formatSource` clean.