### PR TITLE
LPD-92325 Move criteria validation to form level

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/index.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/index.tsx
@@ -239,6 +239,13 @@ class SegmentEditor extends React.Component<ISegmentEditorProps> {
 						}}
 						innerRef={this._formRef as any}
 						onSubmit={this.handleSubmit}
+						validate={(values: FormValues) => {
+							const error = validateSegmentEditor(
+								values.criteria
+							);
+
+							return error ? {criteria: error} : {};
+						}}
 					>
 						{({
 							handleSubmit,
@@ -394,9 +401,6 @@ class SegmentEditor extends React.Component<ISegmentEditorProps> {
 															segmentType={type}
 															sequential={
 																sequential
-															}
-															validate={
-																validateSegmentEditor
 															}
 														/>
 													</div>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92325

## What is being fixed

The criteria field's `validate` callback is attached at the field level via Formik's `<Field validate=...>`. Formik field-level validators only re-run when their own field value changes — toggling a sibling field does not trigger re-validation, even when the validator closure depends on it. This is benign today because `validateSegmentEditor` only inspects the criteria, but the validator will need to consider sibling values such as `sequential` once LPD-85247 lands the Real-Time sequential limits, and the stale-closure pitfall would silently bypass the save guard the moment any sibling toggles.

## How it is being fixed

Move the `validateSegmentEditor` call from the criteria field's `<Field validate=...>` prop to the Form's top-level `validate(values)` prop. Form-level Formik validators run on every form value change, so any future signature that consumes additional values (such as `sequential`) re-evaluates correctly whenever any of those values change. The error is published to the `criteria` field through the returned errors map, preserving the current per-field error UX.

## Why are there no tests?

`validateSegmentEditor` is a pure function and is already covered by the existing unit tests in `__tests__/SegmentEditor.jsx`. The change is purely about *when* Formik invokes the validator; a faithful regression test would require mounting the full SegmentEditor with Formik, react-dnd, and Redux, then asserting on the form's `isValid` after several field changes — out of scope for this small, structural refactor.