### PR TITLE
LPD-92325 Move criteria validation to form level and validate on mount

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/index.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/index.tsx
@@ -239,6 +239,13 @@ class SegmentEditor extends React.Component<ISegmentEditorProps> {
 						}}
 						innerRef={this._formRef as any}
 						onSubmit={this.handleSubmit}
+						validate={(values: FormValues) => {
+							const error = validateSegmentEditor(
+								values.criteria
+							);
+
+							return error ? {criteria: error} : {};
+						}}
 					>
 						{({
 							handleSubmit,
@@ -394,9 +401,6 @@ class SegmentEditor extends React.Component<ISegmentEditorProps> {
 															segmentType={type}
 															sequential={
 																sequential
-															}
-															validate={
-																validateSegmentEditor
 															}
 														/>
 													</div>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/index.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/index.tsx
@@ -246,6 +246,7 @@ class SegmentEditor extends React.Component<ISegmentEditorProps> {
 
 							return error ? {criteria: error} : {};
 						}}
+						validateOnMount
 					>
 						{({
 							handleSubmit,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92325

## What is being fixed

The Save Segment button can remain enabled when the criteria are invalid in two cases:

1. On initial mount of an existing segment whose stored criteria fail the current validator — the field-level `validate` callback runs on field changes, not on the initial render, so `isValid` starts `true` and the Save button stays enabled until the user touches a field.

2. After toggling a sibling form value (such as `sequential`, once the LPD-85247 Real-Time work lands) — Formik field-level validators only re-run when the field they are attached to changes; sibling-value changes do not refresh the criteria error, so the verdict goes stale.

## How it is being fixed

Move the `validateSegmentEditor` call from the criteria field's `<Field validate=...>` prop to the Form's top-level `validate(values)` prop, and add `validateOnMount`. Form-level Formik validators run on every form value change, so any future signature that consumes additional values (such as `sequential`) re-evaluates correctly whenever any of those values change. The `validateOnMount` flag makes the validator run on the initial render too, so a segment that loads with invalid criteria publishes the error to the form immediately and the Save button reflects the up-to-date validity from the first paint. The error is mapped under the `criteria` field via the returned errors map, preserving the per-field error UX.

## Why are there no tests?

`validateSegmentEditor` is a pure function and is already covered by the existing unit tests in `__tests__/SegmentEditor.jsx`. The change is purely about *when* Formik invokes the validator; a faithful regression test would require mounting the full SegmentEditor with Formik, react-dnd, and Redux, then asserting on the form's `isValid` after each Formik lifecycle hook fires — out of scope for this small, structural refactor.