### PR TITLE
LPD-91173 faro-v4.15.x Supports COOKIE session for proxying to internal envs

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/webpack.dev.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/webpack.dev.js
@@ -1,5 +1,5 @@
 const common = require('./webpack.common');
-const {createOnProxyRes} = require('./webpack.dev.proxy');
+const {createOnProxyReq, createOnProxyRes} = require('./webpack.dev.proxy');
 const {merge} = require('webpack-merge');
 const webpack = require('webpack');
 
@@ -9,6 +9,8 @@ const TARGET = (process.env.FARO_URL || 'http://0.0.0.0:8080').replace(
 	/\/$/,
 	''
 );
+
+const COOKIE = process.env.FARO_COOKIE || '';
 
 module.exports = merge(common.config, {
 	devServer: {
@@ -20,6 +22,7 @@ module.exports = merge(common.config, {
 		proxy: {
 			'**': {
 				changeOrigin: true,
+				onProxyReq: createOnProxyReq(COOKIE),
 				onProxyRes: createOnProxyRes(TARGET),
 				selfHandleResponse: true,
 				target: TARGET

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/webpack.dev.proxy.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/webpack.dev.proxy.js
@@ -11,6 +11,19 @@ const inflate = promisify(zlib.inflate);
 // Set-Cookie Domain, and the body) so the browser stays on the dev server
 // instead of leaving for the upstream host.
 
+// Injects an authenticated session Cookie (copied from a browser already logged
+// in via Okta against an SSO-protected upstream such as analytics-internal) into
+// every proxied request, so the dev server can reach the upstream without
+// proxying the Okta redirect flow. A falsy cookie leaves the request untouched.
+
+function createOnProxyReq(cookie) {
+	return function onProxyReq(proxyReq) {
+		if (cookie) {
+			proxyReq.setHeader('cookie', cookie);
+		}
+	};
+}
+
 function createOnProxyRes(target) {
 	return async function onProxyRes(proxyRes, req, res) {
 		const proxyOrigin = `http://${req.headers.host}`;
@@ -95,4 +108,4 @@ function createOnProxyRes(target) {
 	};
 }
 
-module.exports = {createOnProxyRes};
+module.exports = {createOnProxyReq, createOnProxyRes};


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91173

Backport of liferay-ac/liferay-portal#3398 to `faro-v4.15.x`. Only the LPD-91173 commit applies — the LPD-92211 dependency commits are already on `faro-v4.15.x`.