### PR TITLE
LPD-92679 Copy the metrics array before sorting in the audience report

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/audience-report/__tests__/util.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/audience-report/__tests__/util.ts
@@ -1,0 +1,30 @@
+import {formatData} from '../util';
+
+describe('formatData', () => {
+	/**
+	 * Apollo Client 3 deep-freezes query results in development to surface
+	 * accidental mutations. formatData must therefore not sort the metrics
+	 * array in place, otherwise Array.prototype.sort throws "Cannot assign to
+	 * read only property '0'" as soon as the channel has two or more segments.
+	 */
+	it('does not mutate the frozen metrics array returned by the Apollo cache', () => {
+		const metrics = Object.freeze([
+			{value: 434, valueKey: '804330050123744518'},
+			{value: 214, valueKey: '804357143036930828'},
+			{value: 141, valueKey: 'Liferayers'}
+		]);
+
+		expect(() =>
+			formatData({
+				audienceReport: {
+					anonymousUsersCount: 100,
+					knownUsersCount: 100,
+					nonsegmentedKnownUsersCount: 40,
+					segmentedAnonymousUsersCount: 30,
+					segmentedKnownUsersCount: 30
+				},
+				segment: {metrics, total: 789}
+			})
+		).not.toThrow();
+	});
+});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/audience-report/util.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/audience-report/util.ts
@@ -212,6 +212,7 @@ export const formatData = ({
 		{
 			segments: [
 				...metrics
+					.slice()
 					.sort((a: any, b: any) => b.value - a.value)
 					.filter(({valueKey}: any) => valueKey !== 'others'),
 				...metrics.filter(({valueKey}: any) => valueKey === 'others')


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92679

## What is being fixed

The Audience Report card crashes when an asset or page has two or more viewer segments. `formatData` sorts the `metrics` array from the Apollo query in place, and Apollo Client 3 deep-freezes query results in development, so the in-place `Array.prototype.sort()` writes to a read-only array and throws `TypeError: Cannot assign to read only property '0'`, taking down the whole audience report subtree.

## How it is being fixed

`formatData` now sorts a shallow copy (`metrics.slice().sort(...)`) instead of the frozen array, leaving the cached result untouched. A unit test freezes the `metrics` input and asserts that `formatData` does not throw. This also matters in production builds, where Apollo does not freeze results and the previous code silently mutated the cached array in place.
