### PR TITLE
LPD-94148 Enable AI Hub feature flag

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-docker/cloud/configs/portal-all.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-docker/cloud/configs/portal-all.properties
@@ -6,6 +6,7 @@ company.default.web.id=liferay.com
 terms.of.use.required=false
 passwords.default.policy.change.required=false
 feature.flag.LPD-34594=true
+feature.flag.LPD-62272=true
 feature.flag.LPS-164563=true
 retry.jdbc.on.startup.delay=5
 retry.jdbc.on.startup.max.retries=5

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-docker/local/common/resources/portal-ext.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-docker/local/common/resources/portal-ext.properties
@@ -22,6 +22,7 @@ browser.launcher.url=
 combo.check.timestamp=true
 direct.servlet.context.reload=true
 feature.flag.LPD-34594=true
+feature.flag.LPD-62272=true
 feature.flag.LPS-164563=true
 module.framework.properties.lpkg.index.validator.enabled=false
 module.framework.properties.osgi.console=0.0.0.0:11311


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94148

## What Is Being Fixed

The AI Hub feature, gated behind the LPD-62272 portal feature flag, is not enabled in the osb-faro deploy configurations, so it cannot be exercised in the local, STG, or INTERNAL Analytics Cloud environments.

## How It Is Being Fixed

The flag is turned on by adding `feature.flag.LPD-62272=true` to the two osb-faro deploy configuration files: the local Docker config (`osb-faro-docker/local/common/resources/portal-ext.properties`) and the cloud image config (`osb-faro-docker/cloud/configs/portal-all.properties`). This mirrors how the existing flags (LPD-34594, LPS-164563) are enabled. Note that the single cloud image is shared across STG, INTERNAL, and PROD, so the flag becomes active in all cloud environments built from this commit.

## Why Are There No Tests?

This change only enables an existing portal feature flag through deploy configuration properties. There is no code logic to cover with automated tests — the change is configuration-only, analogous to a language-key or properties update.

## PR Check

**pr-check: PASS** — tested on `e565f5c84d3acd93bddf3b1dc9fca894b73aeb7b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |

Per-Module Deploy matched mechanically (the diff is `modules/**/*.properties`) but there is no deployable bundle — `osb-faro-docker` is a Docker image build context with no `bnd.bnd`, so there is nothing to `gradlew deploy`.

<!-- pr-check {"result": "success", "sha": "e565f5c84d3acd93bddf3b1dc9fca894b73aeb7b"} -->
